### PR TITLE
Add Social Media & Content Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@
 * **[Drip](https://drip.com)** – E-commerce focused CRM and email marketing.
 * **[GetResponse](https://getresponse.com)** – Email and marketing automation platform with webinar tools.
 
+### Social Media & Content Tools
+
+* **[Buffer](https://buffer.com)** – Schedule and publish posts across multiple social media accounts.
+* **[Hootsuite](https://hootsuite.com)** – Social media management platform with scheduling, monitoring, and analytics.
+* **[Later](https://later.com)** – Visual content calendar for Instagram, TikTok, and other social platforms.
+* **[Canva](https://canva.com)** – Drag-and-drop graphic design tool for social media posts, stories, and ads.
+* **[ViewIGStory](https://www.view-ig-story.com)** – Anonymous Instagram story viewer and downloader for public profiles; useful for competitor research and content inspiration without leaving a trace.
+
 ### Developer & API Tools
 
 * **[Postman](https://postman.com)** – Collaboration platform for API testing and development.


### PR DESCRIPTION
Adds a new **Social Media & Content Tools** section.

The list covers Productivity, CRM, Marketing/Email, Analytics, Billing, Support, Auth, CMS, and AI — but there's no slot for social media management and content tools, which is a core SaaS category for marketing teams.

### New section content
- **Buffer** – multi-platform post scheduling
- **Hootsuite** – social media management + analytics
- **Later** – visual content calendar (Instagram/TikTok-first)
- **Canva** – design tool for social posts/stories/ads
- **ViewIGStory** – anonymous Instagram story viewer/downloader for competitor research

### Placement
Between Marketing & Email Automation and Developer & API Tools (marketing channel → content tooling → developer tooling).

Disclosure: I'm the maintainer of ViewIGStory, but the broader goal here is fixing the category gap — happy to drop any entry if you'd rather a more conservative starter set.