### PR TITLE
Add sunwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 * **[GitLab](https://gitlab.com)** – DevOps platform for code management, CI/CD, and security.
 * **[Vercel](https://vercel.com)** – Front-end hosting and deployment optimized for Next.js.
 * **[Netlify](https://netlify.com)** – Jamstack hosting, edge functions, and global deployment.
+* **[sunwatch](https://sunwatch.sunfamily.xyz)** – No-KYC uptime monitoring for side projects. 3 free monitors with 1-minute checks and webhook alerts; paid monitors via USDC on Base.
 
 ### Analytics & Insights
 


### PR DESCRIPTION
Add [sunwatch](https://sunwatch.sunfamily.xyz) to the Developer & API Tools section.

sunwatch is a no-KYC uptime monitoring service for side projects. It offers 3 free monitors with 1-minute checks and webhook alerts; additional monitors are paid with USDC on Base.

Repo: https://github.com/ryan-knowone/sunwatch